### PR TITLE
[REFACT] 서버에서 중복 오류시, error 메세지 발생시키고 버튼 비활성화 하기 #NADA-26

### DIFF
--- a/src/containers/auth/register/EmailForm.js
+++ b/src/containers/auth/register/EmailForm.js
@@ -34,13 +34,16 @@ const EmailForm = ({ dispatchField, onSubmit, order, type }) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const { data } = await client.get('user/email', {
+        const { status } = await client.get('user/email', {
           params: { email: email },
         });
-        setError(data.result ? null : errorMessages.email_duplicate);
-        setDisabled(!data.result);
+        if (status === 200) {
+          setError(null);
+          setDisabled(false);
+        }
       } catch (error) {
-        console.error('데이터 가져오기 오류:', error);
+        setError(errorMessages.email_duplicate);
+        setDisabled(true);
       }
     };
 


### PR DESCRIPTION
react-query를 사용하고 싶었지만, enabled 속성을 사용해 checkEmail을 실행하면, setError가 변경되고 이를 useEffect에서 query의 결과값을 바탕으로 setError를 변경할때 무한 루프에 빠지게 됩니다. 그래서 이 경우엔 react-query를 사용하지 않았습니다