### PR TITLE
Nada 60 뱃지 화면 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ import SearchActivityPage from './Acitivity/pages/SearchActivityPage';
 import BadgePage from './Badge/pages/BadgePage';
 import DetailBadgePage from './Badge/pages/DetailBadgePage';
 import ActWritePage from './Acitivity/pages/ActWritePage';
+import BadgeRegisterPage from './Badge/pages/BadgeRegisterPage';
 
 const App = () => {
   return (
@@ -63,6 +64,7 @@ const App = () => {
 
         <Route path="/badge" element={<BadgePage />} />
         <Route path="/badge/detail" element={<DetailBadgePage />} />
+        <Route path="/badge/write" element={<BadgeRegisterPage />} />
       </Routes>
       <StyledToastContainer limit={1} />
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -64,7 +64,7 @@ const App = () => {
 
         <Route path="/badge" element={<BadgePage />} />
         <Route path="/badge/detail" element={<DetailBadgePage />} />
-        <Route path="/badge/write" element={<BadgeRegisterPage />} />
+        <Route path="/badge/BadgeRegister" element={<BadgeRegisterPage />} />
       </Routes>
       <StyledToastContainer limit={1} />
     </div>

--- a/src/Auth/components/AuthForm.js
+++ b/src/Auth/components/AuthForm.js
@@ -1,5 +1,5 @@
 // 회원가입 또는 로그인 폼을 보여주기
-import { InputBox, LoginBtn } from '../styles/Auth';
+import { InputBox, LoginBtn } from '../../styles/Survey';
 
 const AuthForm = ({ form, onChange, onSubmit }) => {
   return (

--- a/src/Auth/components/Caution.js
+++ b/src/Auth/components/Caution.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { ErrorMessage } from '../styles/Auth';
+import { ErrorMessage } from '../../styles/Survey';
 import { WarningSvg } from '../../icon/WarningSvg';
 
 const CautionBox = styled.div`

--- a/src/Auth/components/CheckList/CheckListItem.js
+++ b/src/Auth/components/CheckList/CheckListItem.js
@@ -1,4 +1,4 @@
-import { ErrorMessage } from '../../styles/Auth';
+import { ErrorMessage } from '../../../styles/Survey';
 import { CheckSvg } from '../../../icon/Login/CheckSvg';
 
 const CheckListItem = ({ text, checked }) => {

--- a/src/Auth/components/Title.js
+++ b/src/Auth/components/Title.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TitleBox } from '../styles/Auth';
+import { TitleBox } from '../../styles/Survey';
 
 const Title = ({ text }) => {
   return (

--- a/src/Auth/containers/login/LoginFooter.js
+++ b/src/Auth/containers/login/LoginFooter.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { RightArrowSvg } from '../../../icon/Login/RightArrowSvg';
-import { FooterWrapper } from '../../styles/Auth';
+import { FooterWrapper } from '../../../styles/Survey';
 
 const LoginFooter = ({ type }) => {
   return (

--- a/src/Auth/containers/login/SocialLogin.js
+++ b/src/Auth/containers/login/SocialLogin.js
@@ -1,4 +1,4 @@
-import { FooterWrapper } from '../../styles/Auth';
+import { FooterWrapper } from '../../../styles/Survey';
 
 const SocialLogin = () => {
   return (

--- a/src/Auth/containers/register/EmailForm.js
+++ b/src/Auth/containers/register/EmailForm.js
@@ -7,7 +7,7 @@ import { useCallback } from 'react';
 import Title from '../../components/Title';
 import Caution from '../../components/Caution';
 import useDebounce from '../../modules/useDebounce';
-import { LoginBtn, InputBox } from '../../styles/Auth';
+import { LoginBtn, InputBox } from '../../../styles/Survey';
 
 const EmailForm = ({ dispatchField, onSubmit, order, type }) => {
   const errorMessages = {

--- a/src/Auth/containers/register/FieldForm.js
+++ b/src/Auth/containers/register/FieldForm.js
@@ -1,6 +1,6 @@
 // 회원가입 - 관심분야를 입력받는 컨테이너
 import { authSelector } from '../../modules/redux/auth';
-import { TitleBox, Explain, LoginBtn } from '../../styles/Auth';
+import { TitleBox, Explain, LoginBtn } from '../../../styles/Survey';
 import { useState } from 'react';
 import { fieldData } from '../../../modules/common/AttributeData';
 import { Item } from '../../../components/common/filter/FilterItems';

--- a/src/Auth/containers/register/PasswordForm.js
+++ b/src/Auth/containers/register/PasswordForm.js
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { produce } from 'immer';
 import { useSelector } from 'react-redux';
 import { authSelector } from '../../modules/redux/auth';
-import { LoginBtn, InputBox } from '../../styles/Auth';
+import { LoginBtn, InputBox } from '../../../styles/Survey';
 import CheckList from '../../components/CheckList/CheckList';
 import Title from '../../components/Title';
 const PasswordForm = ({ dispatchField, onSubmit, order, type }) => {

--- a/src/Auth/containers/register/PhoneNumberForm.js
+++ b/src/Auth/containers/register/PhoneNumberForm.js
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useState } from 'react';
-import { LoginBtn, InputBox } from '../../styles/Auth';
+import { LoginBtn, InputBox } from '../../../styles/Survey';
 import { useEffect } from 'react';
 import { authSelector } from '../../modules/redux/auth';
 import { useSelector } from 'react-redux';

--- a/src/Auth/containers/register/RegionForm.js
+++ b/src/Auth/containers/register/RegionForm.js
@@ -1,6 +1,6 @@
 // 회원가입 - 활동 지역을 입력받는 컨테이너
 import { authSelector } from '../../modules/redux/auth';
-import { TitleBox, Explain, LoginBtn } from '../../styles/Auth';
+import { TitleBox, Explain, LoginBtn } from '../../../styles/Survey';
 import { Item } from '../../../components/common/filter/FilterItems';
 import { useState } from 'react';
 import { regionData } from '../../../modules/common/AttributeData';

--- a/src/Auth/containers/register/RepresentForm.js
+++ b/src/Auth/containers/register/RepresentForm.js
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { authSelector } from '../../modules/redux/auth';
-import { LoginBtn, InputBox } from '../../styles/Auth';
+import { LoginBtn, InputBox } from '../../../styles/Survey';
 import Title from '../../components/Title';
 import Caution from '../../components/Caution';
 

--- a/src/Auth/containers/register/TeamNameForm.js
+++ b/src/Auth/containers/register/TeamNameForm.js
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 import { authSelector } from '../../modules/redux/auth';
-import { LoginBtn, InputBox } from '../../styles/Auth';
+import { LoginBtn, InputBox } from '../../../styles/Survey';
 import Title from '../../components/Title';
 
 const TeamNameForm = ({ dispatchField, onSubmit, order, type }) => {

--- a/src/Auth/containers/register/TeamTypeForm.js
+++ b/src/Auth/containers/register/TeamTypeForm.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import TeamTypeList from '../../components/TeamType/TeamTypeList';
 import Title from '../../components/Title';
-import { LoginBtn } from '../../styles/Auth';
+import { LoginBtn } from '../../../styles/Survey';
 import { useSelector } from 'react-redux';
 import { authSelector } from '../../modules/redux/auth';
 

--- a/src/Auth/containers/register/UserNameForm.js
+++ b/src/Auth/containers/register/UserNameForm.js
@@ -4,7 +4,7 @@ import client from '../../../lib/api/client';
 import { authSelector } from '../../modules/redux/auth';
 import { produce } from 'immer';
 import CheckList from '../../components/CheckList/CheckList';
-import { LoginBtn, InputBox } from '../../styles/Auth';
+import { LoginBtn, InputBox } from '../../../styles/Survey';
 import Title from '../../components/Title';
 import Caution from '../../components/Caution';
 import useDebounce from '../../modules/useDebounce';

--- a/src/Auth/pages/LoginPage.js
+++ b/src/Auth/pages/LoginPage.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import LoginForm from '../containers/login/LoginForm';
-import { LoginBox } from '../styles/Auth';
+import { LoginBox } from '../../styles/Survey';
 import { useLocation } from 'react-router-dom';
 import { changeBarStatus } from '../../Bar/modules/redux/bar';
 import { useDispatch } from 'react-redux';

--- a/src/Auth/pages/LoginSelect.js
+++ b/src/Auth/pages/LoginSelect.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { LoginBox, LoginBtn } from '../styles/Auth';
+import { LoginBox, LoginBtn } from '../../styles/Survey';
 import { Link } from 'react-router-dom';
 import { changeBarStatus } from '../../Bar/modules/redux/bar';
 import { useDispatch } from 'react-redux';

--- a/src/Auth/pages/RegisterPage.js
+++ b/src/Auth/pages/RegisterPage.js
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 import { changeBarStatus } from '../../Bar/modules/redux/bar';
 import { useDispatch } from 'react-redux';
-import { RegisterBox } from '../styles/Auth';
+import { RegisterBox } from '../../styles/Survey';
 
 const RegisterPage = () => {
   const dispatch = useDispatch();

--- a/src/Badge/components/ActivityInputItem.js
+++ b/src/Badge/components/ActivityInputItem.js
@@ -4,8 +4,11 @@ import { FilterHandler } from '../../icon/FilterHandler';
 import { X } from '../../icon/X';
 import { InputBox } from '../../styles/Survey';
 import { applyFontStyles } from '../../styles/fontStyle';
+import { useDispatch } from 'react-redux';
+import { deleteActivities } from '../modules/redux/badge';
 
 const InputContainer = styled(InputBox)`
+  margin: 40px auto;
   & > .inputWrapper {
     display: flex;
     justify-content: space-between;
@@ -28,7 +31,11 @@ const InputContainer = styled(InputBox)`
   }
 `;
 
-const ActivityInputItem = () => {
+const ActivityInputItem = ({ index }) => {
+  const dispatch = useDispatch();
+  const onClick = () => {
+    dispatch(deleteActivities(index));
+  };
   return (
     <InputContainer>
       <div className="inputWrapper">
@@ -37,7 +44,9 @@ const ActivityInputItem = () => {
           placeholder="내용을 입력해주세요."
           required
         />
-        <X size={12} bold={2} />
+        <div onClick={() => onClick()}>
+          <X size={12} bold={2} />
+        </div>
       </div>
       <div className="dateWrapper">
         <Dropdown className={'unselected'}>

--- a/src/Badge/components/ActivityInputItem.js
+++ b/src/Badge/components/ActivityInputItem.js
@@ -4,8 +4,8 @@ import { FilterHandler } from '../../icon/FilterHandler';
 import { X } from '../../icon/X';
 import { InputBox } from '../../styles/Survey';
 import { applyFontStyles } from '../../styles/fontStyle';
-import { useDispatch } from 'react-redux';
-import { deleteActivities } from '../modules/redux/badge';
+import { useDispatch, useSelector } from 'react-redux';
+import { deleteActivities, changeActivities } from '../modules/redux/badge';
 
 const InputContainer = styled(InputBox)`
   margin: 40px auto;
@@ -33,15 +33,28 @@ const InputContainer = styled(InputBox)`
 
 const ActivityInputItem = ({ index }) => {
   const dispatch = useDispatch();
+
+  const activitiyContent = useSelector(
+    ({ badge }) => badge.activities[index].content,
+  );
+
   const onClick = () => {
     dispatch(deleteActivities(index));
   };
+
+  const onChange = (e) => {
+    const { value, name } = e.target;
+    dispatch(changeActivities({ index, name, value }));
+  };
+
   return (
     <InputContainer>
       <div className="inputWrapper">
         <input
-          name="activityList"
+          name="content"
           placeholder="내용을 입력해주세요."
+          onChange={(e) => onChange(e)}
+          value={activitiyContent}
           required
         />
         <div onClick={() => onClick()}>

--- a/src/Badge/components/ActivityInputItem.js
+++ b/src/Badge/components/ActivityInputItem.js
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+import { Dropdown, TextWarpper } from '../../Community/styles/DropdownStyle';
+import { FilterHandler } from '../../icon/FilterHandler';
+import { X } from '../../icon/X';
+import { InputBox } from '../../styles/Survey';
+import { applyFontStyles } from '../../styles/fontStyle';
+
+const InputContainer = styled(InputBox)`
+  & > .inputWrapper {
+    display: flex;
+    justify-content: space-between;
+
+    input {
+      background: var(--myspec-gray-scalegray-100);
+      width: calc(100% - 12px - 16px); // 전체화면 - X.svg - gap
+    }
+  }
+
+  & > .dateWrapper {
+    display: flex;
+
+    & > span {
+      ${applyFontStyles({
+        font: 'title-01',
+        color: 'var(--myspec-gray-scalegray-500)',
+      })}
+    }
+  }
+`;
+
+const ActivityInputItem = () => {
+  return (
+    <InputContainer>
+      <div className="inputWrapper">
+        <input
+          name="activityList"
+          placeholder="내용을 입력해주세요."
+          required
+        />
+        <X size={12} bold={2} />
+      </div>
+      <div className="dateWrapper">
+        <Dropdown className={'unselected'}>
+          <TextWarpper className={'unselected'}>2023.01</TextWarpper>
+          <FilterHandler className={'unselected'} />
+        </Dropdown>
+        <span> ~ </span>
+        <Dropdown className={'unselected'}>
+          <TextWarpper className={'unselected'}>2023.02</TextWarpper>
+          <FilterHandler className={'unselected'} />
+        </Dropdown>
+      </div>
+    </InputContainer>
+  );
+};
+
+export default ActivityInputItem;

--- a/src/Badge/components/ActivityInputItem.js
+++ b/src/Badge/components/ActivityInputItem.js
@@ -1,3 +1,4 @@
+// 활동 이력을 입력받는 컴포넌트
 import styled from 'styled-components';
 import { Dropdown, TextWarpper } from '../../Community/styles/DropdownStyle';
 import { FilterHandler } from '../../icon/FilterHandler';

--- a/src/Badge/components/ActivityTable.js
+++ b/src/Badge/components/ActivityTable.js
@@ -1,3 +1,4 @@
+// 활동 이력을 보여주는 컴포넌트
 import React from 'react';
 
 export const ActivityTable = ({ info }) => {

--- a/src/Badge/components/AlignBox.js
+++ b/src/Badge/components/AlignBox.js
@@ -1,3 +1,4 @@
+// ['연도별', '종류별'] 정렬
 import { applyFontStyles } from '../../styles/fontStyle';
 
 export const AlignBox = ({ text, onClick }) => {

--- a/src/Badge/components/BadgeItem.js
+++ b/src/Badge/components/BadgeItem.js
@@ -1,3 +1,4 @@
+// 뱃지를 보여주는 아이템 [shape, type, title, team, role]
 import styled from 'styled-components';
 import { body_01, caption_02, subtitle_01 } from '../../styles/fontStyle';
 

--- a/src/Badge/components/ContentBox.js
+++ b/src/Badge/components/ContentBox.js
@@ -1,3 +1,4 @@
+// 뱃지 설명 컴포넌트
 import React from 'react';
 import { applyFontStyles } from '../../styles/fontStyle';
 

--- a/src/Badge/components/IssueBadgeBtn.js
+++ b/src/Badge/components/IssueBadgeBtn.js
@@ -1,3 +1,4 @@
+// '뱃지 발급하기' 버튼
 import styled from 'styled-components';
 import { AddOperator } from '../../icon/AddOperator';
 import { applyFontStyles } from '../../styles/fontStyle';

--- a/src/Badge/components/ShapeGrid.js
+++ b/src/Badge/components/ShapeGrid.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+const GridContainer = styled.div`
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  gap: 11px;
+  padding-bottom: 120px;
+
+  & > div {
+    width: 167px;
+    aspect-ratio: 1/1;
+    border-radius: 20px;
+    background-color: var(--myspec-gray-scalegray-100, #f8f8f8);
+  }
+`;
+const ShapeGrid = () => {
+  return (
+    <GridContainer>
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+    </GridContainer>
+  );
+};
+
+export default ShapeGrid;

--- a/src/Badge/components/ShapeGrid.js
+++ b/src/Badge/components/ShapeGrid.js
@@ -1,3 +1,4 @@
+// 뱃지 모양 보여주는 그리드 컴포넌트
 import styled from 'styled-components';
 
 const GridContainer = styled.div`

--- a/src/Badge/containers/BadgeList.js
+++ b/src/Badge/containers/BadgeList.js
@@ -1,3 +1,4 @@
+// 뱃지 아이템을 리스트로 보여주는 컨테이너
 import { BadgeItem } from '../components/BadgeItem';
 import { applyFontStyles } from '../../styles/fontStyle';
 import { FixedSizeList as List } from 'react-window';

--- a/src/Badge/containers/register/ActivityForm.js
+++ b/src/Badge/containers/register/ActivityForm.js
@@ -7,6 +7,8 @@ import {
 } from '../../../Modal/components/usedInModal/ModalButtonDiv';
 import styled from 'styled-components';
 import { applyFontStyles } from '../../../styles/fontStyle';
+import { useDispatch, useSelector } from 'react-redux';
+import { addActivities } from '../../modules/redux/badge';
 
 const ButtonContainer = styled(ButtonList)`
   width: 100%;
@@ -19,6 +21,13 @@ const ButtonContainer = styled(ButtonList)`
 `;
 
 const ActivityForm = ({ onSubmit, order, dispatchField }) => {
+  const activities = useSelector(({ badge }) => badge.activities);
+  const dispatch = useDispatch();
+
+  const onClick = () => {
+    dispatch(addActivities({ content: '', started: '', end: '' }));
+  };
+
   return (
     <>
       <TitleBox>
@@ -26,10 +35,12 @@ const ActivityForm = ({ onSubmit, order, dispatchField }) => {
         활동 내역을 추가해 주세요
       </TitleBox>
       <form onSubmit={onSubmit} id={order}>
-        <ActivityInputItem />
+        {activities.map((el, index) => (
+          <ActivityInputItem key={index} content={el} index={index} />
+        ))}
       </form>
       <ButtonContainer>
-        <Cancel>
+        <Cancel onClick={() => onClick()}>
           <div className="text">내역 추가하기</div>
         </Cancel>
         <Act>

--- a/src/Badge/containers/register/ActivityForm.js
+++ b/src/Badge/containers/register/ActivityForm.js
@@ -1,5 +1,7 @@
-import { InputBox, TitleBox } from '../../../styles/Survey';
+import { TitleBox } from '../../../styles/Survey';
+import ActivityInputItem from '../../components/ActivityInputItem';
 import { FixedLoginBtn } from './ShapeForm';
+
 const ActivityForm = ({ onSubmit, order, dispatchField }) => {
   return (
     <>
@@ -8,7 +10,7 @@ const ActivityForm = ({ onSubmit, order, dispatchField }) => {
         활동 내역을 추가해 주세요
       </TitleBox>
       <form onSubmit={onSubmit} id={order}>
-        <InputBox>{/* 액티비티 입력 박스 */}</InputBox>
+        <ActivityInputItem />
       </form>
       <FixedLoginBtn form={order} disabled={false}>
         <div>다음</div>

--- a/src/Badge/containers/register/ActivityForm.js
+++ b/src/Badge/containers/register/ActivityForm.js
@@ -1,0 +1,20 @@
+import { InputBox, TitleBox } from '../../../styles/Survey';
+import { FixedLoginBtn } from './ShapeForm';
+const ActivityForm = ({ onSubmit, order, dispatchField }) => {
+  return (
+    <>
+      <TitleBox>
+        거의 다 왔어요 <br />
+        활동 내역을 추가해 주세요
+      </TitleBox>
+      <form onSubmit={onSubmit} id={order}>
+        <InputBox>{/* 액티비티 입력 박스 */}</InputBox>
+      </form>
+      <FixedLoginBtn form={order} disabled={false}>
+        <div>다음</div>
+      </FixedLoginBtn>
+    </>
+  );
+};
+
+export default ActivityForm;

--- a/src/Badge/containers/register/ActivityForm.js
+++ b/src/Badge/containers/register/ActivityForm.js
@@ -1,6 +1,22 @@
 import { TitleBox } from '../../../styles/Survey';
 import ActivityInputItem from '../../components/ActivityInputItem';
-import { FixedLoginBtn } from './ShapeForm';
+import {
+  ButtonList,
+  Cancel,
+  Act,
+} from '../../../Modal/components/usedInModal/ModalButtonDiv';
+import styled from 'styled-components';
+import { applyFontStyles } from '../../../styles/fontStyle';
+
+const ButtonContainer = styled(ButtonList)`
+  width: 100%;
+  & > div {
+    height: fit-content;
+    & > .text {
+      ${applyFontStyles({ font: 'title-01' })}
+    }
+  }
+`;
 
 const ActivityForm = ({ onSubmit, order, dispatchField }) => {
   return (
@@ -12,9 +28,16 @@ const ActivityForm = ({ onSubmit, order, dispatchField }) => {
       <form onSubmit={onSubmit} id={order}>
         <ActivityInputItem />
       </form>
-      <FixedLoginBtn form={order} disabled={false}>
-        <div>다음</div>
-      </FixedLoginBtn>
+      <ButtonContainer>
+        <Cancel>
+          <div className="text">내역 추가하기</div>
+        </Cancel>
+        <Act>
+          <div className="text" style={{ color: 'white' }}>
+            다음
+          </div>
+        </Act>
+      </ButtonContainer>
     </>
   );
 };

--- a/src/Badge/containers/register/ActivityForm.js
+++ b/src/Badge/containers/register/ActivityForm.js
@@ -1,3 +1,4 @@
+// 활동 이력을 입력받는 컨테이너
 import { TitleBox } from '../../../styles/Survey';
 import ActivityInputItem from '../../components/ActivityInputItem';
 import {

--- a/src/Badge/containers/register/ActivityForm.js
+++ b/src/Badge/containers/register/ActivityForm.js
@@ -12,6 +12,9 @@ import { addActivities } from '../../modules/redux/badge';
 
 const ButtonContainer = styled(ButtonList)`
   width: 100%;
+  align-items: end;
+  bottom: 50px;
+
   & > div {
     height: fit-content;
     & > .text {
@@ -34,10 +37,12 @@ const ActivityForm = ({ onSubmit, order, dispatchField }) => {
         거의 다 왔어요 <br />
         활동 내역을 추가해 주세요
       </TitleBox>
-      <form onSubmit={onSubmit} id={order}>
-        {activities.map((el, index) => (
-          <ActivityInputItem key={index} content={el} index={index} />
-        ))}
+      <form onSubmit={onSubmit} id={order} style={{ overflowY: 'scroll' }}>
+        <div>
+          {activities.map((el, index) => (
+            <ActivityInputItem key={index} content={el} index={index} />
+          ))}
+        </div>
       </form>
       <ButtonContainer>
         <Cancel onClick={() => onClick()}>

--- a/src/Badge/containers/register/ExplainForm.js
+++ b/src/Badge/containers/register/ExplainForm.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Explain, InputBox, LoginBtn, TitleBox } from '../../../styles/Survey';
+import { useSelector } from 'react-redux';
+
+const ExplainForm = ({ onSubmit, order, dispatchField }) => {
+  const explain = useSelector(({ badge }) => badge.explain);
+
+  return (
+    <>
+      <TitleBox>
+        뱃지의 설명을 적어 주세요
+        <br />
+        <Explain>
+          어디서 어떤 이유로 발급하는 뱃지인가요?
+          <br />
+          단체의 설명을 적어도 좋아요
+        </Explain>
+      </TitleBox>
+      <form onSubmit={onSubmit} id={order}>
+        <InputBox>
+          <textarea
+            name="explain"
+            placeholder="120자 이내로 입력해 주세요."
+            onChange={dispatchField}
+            value={explain}
+            maxLength={120}
+            required
+          />
+        </InputBox>
+      </form>
+      <LoginBtn
+        form={order}
+        disabled={!(explain.length > 0)}
+        style={{ marginBottom: '50px' }}
+      >
+        <div>다음</div>
+      </LoginBtn>
+    </>
+  );
+};
+
+export default ExplainForm;

--- a/src/Badge/containers/register/ExplainForm.js
+++ b/src/Badge/containers/register/ExplainForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+// 뱃지에 대한 설명을 입력받는 컨테이너
 import { Explain, InputBox, LoginBtn, TitleBox } from '../../../styles/Survey';
 import { useSelector } from 'react-redux';
 

--- a/src/Badge/containers/register/NameForm.js
+++ b/src/Badge/containers/register/NameForm.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { InputBox, LoginBtn, TitleBox } from '../../../Auth/styles/Auth';
+import { InputBox, LoginBtn, TitleBox } from '../../../styles/Survey';
 
 const NameForm = ({ onSubmit, order, dispatchField }) => {
   return (

--- a/src/Badge/containers/register/NameForm.js
+++ b/src/Badge/containers/register/NameForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+// 뱃지 이름을 입력받는 컨테이너
 import { InputBox, LoginBtn, TitleBox } from '../../../styles/Survey';
 import { useSelector } from 'react-redux';
 

--- a/src/Badge/containers/register/NameForm.js
+++ b/src/Badge/containers/register/NameForm.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { InputBox, LoginBtn, TitleBox } from '../../../Auth/styles/Auth';
+
+const NameForm = ({ onSubmit, order, dispatchField }) => {
+  return (
+    <>
+      <TitleBox>
+        뱃지 발급을 시작할게요!
+        <br />
+        뱃지 이름은 어떻게 할까요?
+      </TitleBox>
+      <form onSubmit={onSubmit} id={order}>
+        <InputBox>
+          <input
+            name="name"
+            placeholder="20자 이내로 입력해 주세요."
+            onChange={dispatchField}
+            required
+          />
+        </InputBox>
+      </form>
+      <LoginBtn form={order}>
+        <div>다음</div>
+      </LoginBtn>
+    </>
+  );
+};
+
+export default NameForm;

--- a/src/Badge/containers/register/NameForm.js
+++ b/src/Badge/containers/register/NameForm.js
@@ -19,11 +19,12 @@ const NameForm = ({ onSubmit, order, dispatchField }) => {
             placeholder="20자 이내로 입력해 주세요."
             onChange={dispatchField}
             value={name}
+            maxLength={20}
             required
           />
         </InputBox>
       </form>
-      <LoginBtn form={order}>
+      <LoginBtn form={order} disabled={!(name.length > 0)}>
         <div>다음</div>
       </LoginBtn>
     </>

--- a/src/Badge/containers/register/NameForm.js
+++ b/src/Badge/containers/register/NameForm.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { InputBox, LoginBtn, TitleBox } from '../../../styles/Survey';
+import { useSelector } from 'react-redux';
 
 const NameForm = ({ onSubmit, order, dispatchField }) => {
+  const name = useSelector(({ badge }) => badge.name);
+
   return (
     <>
       <TitleBox>
@@ -15,6 +18,7 @@ const NameForm = ({ onSubmit, order, dispatchField }) => {
             name="name"
             placeholder="20자 이내로 입력해 주세요."
             onChange={dispatchField}
+            value={name}
             required
           />
         </InputBox>

--- a/src/Badge/containers/register/NameForm.js
+++ b/src/Badge/containers/register/NameForm.js
@@ -24,7 +24,11 @@ const NameForm = ({ onSubmit, order, dispatchField }) => {
           />
         </InputBox>
       </form>
-      <LoginBtn form={order} disabled={!(name.length > 0)}>
+      <LoginBtn
+        form={order}
+        disabled={!(name.length > 0)}
+        style={{ marginBottom: '50px' }}
+      >
         <div>다음</div>
       </LoginBtn>
     </>

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { useState, useCallback } from 'react';
-import NameForm from './NameForm';
 import { useDispatch } from 'react-redux';
 import { changeField } from '../../modules/redux/badge';
 import { useNavigate } from 'react-router-dom';
 import { BackSvg } from '../../../icon/BackSvg';
 
 const RegisterForm = () => {
+  const NameForm = lazy(() => import('./NameForm'));
+
   const [order, setOrder] = useState(0);
   const forms = [NameForm];
   const Components = forms[order];
@@ -38,11 +39,13 @@ const RegisterForm = () => {
       <div className="backBtnWrapper" onClick={goBack}>
         <BackSvg />
       </div>
-      <Components
-        dispatchField={dispatchField}
-        onSubmit={onSubmit}
-        order={order}
-      />
+      <Suspense fallback={<div></div>}>
+        <Components
+          dispatchField={dispatchField}
+          onSubmit={onSubmit}
+          order={order}
+        />
+      </Suspense>
     </>
   );
 };

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -36,9 +36,10 @@ const TopContainer = styled.div`
 const RegisterForm = () => {
   const NameForm = lazy(() => import('./NameForm'));
   const ShapeForm = lazy(() => import('./ShapeForm'));
+  const ExplainForm = lazy(() => import('./ExplainForm'));
 
   const [order, setOrder] = useState(0);
-  const forms = [NameForm, ShapeForm];
+  const forms = [NameForm, ShapeForm, ExplainForm];
   const Components = forms[order];
 
   const onSubmit = (e) => {

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -3,6 +3,30 @@ import { useDispatch } from 'react-redux';
 import { changeField } from '../../modules/redux/badge';
 import { useNavigate } from 'react-router-dom';
 import { changeBarStatus } from '../../../Bar/modules/redux/bar';
+import styled from 'styled-components';
+import { applyFontStyles } from '../../../styles/fontStyle';
+
+const Indicator = styled.div`
+  display: inline-flex;
+  justify-self: end;
+  height: fit-content;
+  padding: 2px 12px;
+  gap: 2px;
+  border-radius: 23px;
+  background: var(--myspec-Gray-scale-Gray-300, #e4e4e4);
+  width: fit-content;
+
+  & > span {
+    ${applyFontStyles({
+      font: 'subtitle-01',
+      color: 'var(--myspec-gray-scalegray-600)',
+    })}
+
+    &:nth-child(1) {
+      color: var(--myspec-primaryblue-1);
+    }
+  }
+`;
 
 const RegisterForm = () => {
   const NameForm = lazy(() => import('./NameForm'));
@@ -45,6 +69,11 @@ const RegisterForm = () => {
 
   return (
     <>
+      <Indicator>
+        <span>{order + 1}</span>
+        <span>/</span>
+        <span>{forms.length}</span>
+      </Indicator>
       <Suspense fallback={<div></div>}>
         <Components
           dispatchField={dispatchField}

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -37,9 +37,10 @@ const RegisterForm = () => {
   const NameForm = lazy(() => import('./NameForm'));
   const ShapeForm = lazy(() => import('./ShapeForm'));
   const ExplainForm = lazy(() => import('./ExplainForm'));
+  const ActivityForm = lazy(() => import('./ActivityForm'));
 
   const [order, setOrder] = useState(0);
-  const forms = [NameForm, ShapeForm, ExplainForm];
+  const forms = [NameForm, ShapeForm, ExplainForm, ActivityForm];
   const Components = forms[order];
 
   const onSubmit = (e) => {

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useState, useCallback } from 'react';
 import NameForm from './NameForm';
+import { useDispatch } from 'react-redux';
+import { changeField } from '../../modules/redux/badge';
 
 const RegisterForm = () => {
   const [order, setOrder] = useState(0);
@@ -9,11 +11,16 @@ const RegisterForm = () => {
 
   const onSubmit = (e) => {
     e.preventDefault();
+    if (order === forms.length - 1) {
+      // 마지막 form 입력일때, 뱃지 등록 실행하기
+    } else setOrder(order + 1);
   };
 
+  const dispatch = useDispatch();
   // 입력 값을 상태에 반영하기
   const dispatchField = useCallback((e) => {
     const { value, name } = e.target;
+    dispatch(changeField({ key: name, value }));
   }, []);
 
   return (

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -1,3 +1,4 @@
+// 뱃지 발급의 전 과정을 관리하는 index 컨테이너
 import React, { useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useDispatch } from 'react-redux';
 import { changeField } from '../../modules/redux/badge';

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -3,6 +3,8 @@ import { useState, useCallback } from 'react';
 import NameForm from './NameForm';
 import { useDispatch } from 'react-redux';
 import { changeField } from '../../modules/redux/badge';
+import { useNavigate } from 'react-router-dom';
+import { BackSvg } from '../../../icon/BackSvg';
 
 const RegisterForm = () => {
   const [order, setOrder] = useState(0);
@@ -23,8 +25,19 @@ const RegisterForm = () => {
     dispatch(changeField({ key: name, value }));
   }, []);
 
+  // 뒤로가기
+  const navigate = useNavigate();
+  const goBack = () => {
+    if (order === 0) {
+      navigate(-1);
+    } else setOrder(order - 1);
+  };
+
   return (
     <>
+      <div className="backBtnWrapper" onClick={goBack}>
+        <BackSvg />
+      </div>
       <Components
         dispatchField={dispatchField}
         onSubmit={onSubmit}

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { useState, useCallback } from 'react';
+import NameForm from './NameForm';
+
+const RegisterForm = () => {
+  const [order, setOrder] = useState(0);
+  const forms = [NameForm];
+  const Components = forms[order];
+
+  const onSubmit = (e) => {
+    e.preventDefault();
+  };
+
+  // 입력 값을 상태에 반영하기
+  const dispatchField = useCallback((e) => {
+    const { value, name } = e.target;
+  }, []);
+
+  return (
+    <>
+      <Components
+        dispatchField={dispatchField}
+        onSubmit={onSubmit}
+        order={order}
+      />
+    </>
+  );
+};
+
+export default RegisterForm;

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -1,29 +1,34 @@
 import React, { useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useDispatch } from 'react-redux';
 import { changeField } from '../../modules/redux/badge';
-import { useNavigate } from 'react-router-dom';
 import { changeBarStatus } from '../../../Bar/modules/redux/bar';
 import styled from 'styled-components';
 import { applyFontStyles } from '../../../styles/fontStyle';
 
-const Indicator = styled.div`
-  display: inline-flex;
-  justify-self: end;
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  ${applyFontStyles({
+    font: 'body-01',
+    color: 'var(--myspec-gray-scalegray-600)',
+  })}
   height: fit-content;
-  padding: 2px 12px;
-  gap: 2px;
-  border-radius: 23px;
-  background: var(--myspec-Gray-scale-Gray-300, #e4e4e4);
-  width: fit-content;
 
-  & > span {
-    ${applyFontStyles({
-      font: 'subtitle-01',
-      color: 'var(--myspec-gray-scalegray-600)',
-    })}
+  & > .indicator {
+    padding: 2px 12px;
+    gap: 2px;
+    border-radius: 23px;
+    background: var(--myspec-Gray-scale-Gray-300, #e4e4e4);
+    justify-self: end;
+    & > span {
+      ${applyFontStyles({
+        font: 'subtitle-01',
+        color: 'var(--myspec-gray-scalegray-600)',
+      })}
 
-    &:nth-child(1) {
-      color: var(--myspec-primaryblue-1);
+      &:nth-child(1) {
+        color: var(--myspec-primaryblue-1);
+      }
     }
   }
 `;
@@ -62,11 +67,20 @@ const RegisterForm = () => {
 
   return (
     <>
-      <Indicator>
-        <span>{order + 1}</span>
-        <span>/</span>
-        <span>{forms.length}</span>
-      </Indicator>
+      <TopContainer>
+        <div
+          onClick={() => {
+            setOrder(order - 1);
+          }}
+        >
+          {order > 0 && '뒤로가기'}
+        </div>
+        <div className="indicator">
+          <span>{order + 1}</span>
+          <span>/</span>
+          <span>{forms.length}</span>
+        </div>
+      </TopContainer>
       <Suspense fallback={<div></div>}>
         <Components
           dispatchField={dispatchField}

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -30,9 +30,10 @@ const Indicator = styled.div`
 
 const RegisterForm = () => {
   const NameForm = lazy(() => import('./NameForm'));
+  const ShapeForm = lazy(() => import('./ShapeForm'));
 
   const [order, setOrder] = useState(0);
-  const forms = [NameForm];
+  const forms = [NameForm, ShapeForm];
   const Components = forms[order];
 
   const onSubmit = (e) => {
@@ -48,14 +49,6 @@ const RegisterForm = () => {
     const { value, name } = e.target;
     dispatch(changeField({ key: name, value }));
   }, []);
-
-  // 뒤로가기
-  const navigate = useNavigate();
-  const goBack = () => {
-    if (order === 0) {
-      navigate(-1);
-    } else setOrder(order - 1);
-  };
 
   useEffect(() => {
     dispatch(

--- a/src/Badge/containers/register/RegisterForm.js
+++ b/src/Badge/containers/register/RegisterForm.js
@@ -1,9 +1,8 @@
-import React, { lazy, Suspense } from 'react';
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useDispatch } from 'react-redux';
 import { changeField } from '../../modules/redux/badge';
 import { useNavigate } from 'react-router-dom';
-import { BackSvg } from '../../../icon/BackSvg';
+import { changeBarStatus } from '../../../Bar/modules/redux/bar';
 
 const RegisterForm = () => {
   const NameForm = lazy(() => import('./NameForm'));
@@ -34,11 +33,18 @@ const RegisterForm = () => {
     } else setOrder(order - 1);
   };
 
+  useEffect(() => {
+    dispatch(
+      changeBarStatus({
+        headerState: 'back',
+        text: '뱃지 발급',
+        isShowBottom: false,
+      }),
+    );
+  }, []);
+
   return (
     <>
-      <div className="backBtnWrapper" onClick={goBack}>
-        <BackSvg />
-      </div>
       <Suspense fallback={<div></div>}>
         <Components
           dispatchField={dispatchField}

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+// 뱃지 모양을 입력받는 컨테이너
 import { LoginBtn, TitleBox } from '../../../styles/Survey';
 import styled from 'styled-components';
 import { RightArrowSvg } from '../../../icon/Login/RightArrowSvg';

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { LoginBtn, TitleBox } from '../../../styles/Survey';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+const ShapeForm = ({ onSubmit, order, dispatchField }) => {
+  const name = useSelector(({ badge }) => badge.name);
+
+  return (
+    <>
+      <TitleBox>뱃지 모양을 골라 주세요.</TitleBox>
+      <form onSubmit={onSubmit} id={order}></form>
+      <LoginBtn form={order} style={{ marginBottom: '50px' }}>
+        <div>다음</div>
+      </LoginBtn>
+    </>
+  );
+};
+
+export default ShapeForm;

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -14,7 +14,7 @@ const RoundSpaceBetween = styled(SpaceBetween)`
   box-sizing: border-box;
 `;
 
-const FixedLoginBtn = styled(LoginBtn)`
+export const FixedLoginBtn = styled(LoginBtn)`
   position: fixed;
   max-width: 345px;
   border: none;

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -1,15 +1,27 @@
 import React from 'react';
 import { LoginBtn, TitleBox } from '../../../styles/Survey';
-import { useSelector } from 'react-redux';
 import styled from 'styled-components';
+import { RightArrowSvg } from '../../../icon/Login/RightArrowSvg';
+import { SpaceBetween } from '../../../Search/components/SearchCategory';
+import { applyFontStyles } from '../../../styles/fontStyle';
+
+const RoundSpaceBetween = styled(SpaceBetween)`
+  ${applyFontStyles({ font: 'body-01' })}
+  padding: 13px;
+  border-radius: 20px;
+  background: var(--myspec-gray-scalegray-100, #f8f8f8);
+`;
 
 const ShapeForm = ({ onSubmit, order, dispatchField }) => {
-  const name = useSelector(({ badge }) => badge.name);
-
   return (
     <>
       <TitleBox>뱃지 모양을 골라 주세요.</TitleBox>
-      <form onSubmit={onSubmit} id={order}></form>
+      <form onSubmit={onSubmit} id={order}>
+        <RoundSpaceBetween>
+          <div>사진 업로드하기</div>
+          <RightArrowSvg />
+        </RoundSpaceBetween>
+      </form>
       <LoginBtn form={order} style={{ marginBottom: '50px' }}>
         <div>다음</div>
       </LoginBtn>

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -14,11 +14,12 @@ const RoundSpaceBetween = styled(SpaceBetween)`
   box-sizing: border-box;
 `;
 
-const fixedBtn = {
-  position: 'fixed',
-  maxWidth: '345px',
-  border: 'none',
-};
+const FixedLoginBtn = styled(LoginBtn)`
+  position: fixed;
+  max-width: 345px;
+  border: none;
+  margin-bottom: 50px;
+`;
 
 const ShapeForm = ({ onSubmit, order, dispatchField }) => {
   return (
@@ -31,15 +32,9 @@ const ShapeForm = ({ onSubmit, order, dispatchField }) => {
         </RoundSpaceBetween>
         <ShapeGrid />
       </form>
-      <LoginBtn
-        form={order}
-        style={Object.assign(fixedBtn, {
-          marginBottom: '50px',
-        })}
-        disabled={true}
-      >
+      <FixedLoginBtn form={order} disabled={false}>
         <div>다음</div>
-      </LoginBtn>
+      </FixedLoginBtn>
     </>
   );
 };

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -27,7 +27,7 @@ const ShapeForm = ({ onSubmit, order, dispatchField }) => {
       <form onSubmit={onSubmit} id={order}>
         <RoundSpaceBetween>
           <div>사진 업로드하기</div>
-          <RightArrowSvg />
+          <RightArrowSvg width={8} height={16} />
         </RoundSpaceBetween>
         <ShapeGrid />
       </form>

--- a/src/Badge/containers/register/ShapeForm.js
+++ b/src/Badge/containers/register/ShapeForm.js
@@ -4,13 +4,21 @@ import styled from 'styled-components';
 import { RightArrowSvg } from '../../../icon/Login/RightArrowSvg';
 import { SpaceBetween } from '../../../Search/components/SearchCategory';
 import { applyFontStyles } from '../../../styles/fontStyle';
+import ShapeGrid from '../../components/ShapeGrid';
 
 const RoundSpaceBetween = styled(SpaceBetween)`
   ${applyFontStyles({ font: 'body-01' })}
   padding: 13px;
   border-radius: 20px;
   background: var(--myspec-gray-scalegray-100, #f8f8f8);
+  box-sizing: border-box;
 `;
+
+const fixedBtn = {
+  position: 'fixed',
+  maxWidth: '345px',
+  border: 'none',
+};
 
 const ShapeForm = ({ onSubmit, order, dispatchField }) => {
   return (
@@ -21,8 +29,15 @@ const ShapeForm = ({ onSubmit, order, dispatchField }) => {
           <div>사진 업로드하기</div>
           <RightArrowSvg />
         </RoundSpaceBetween>
+        <ShapeGrid />
       </form>
-      <LoginBtn form={order} style={{ marginBottom: '50px' }}>
+      <LoginBtn
+        form={order}
+        style={Object.assign(fixedBtn, {
+          marginBottom: '50px',
+        })}
+        disabled={true}
+      >
         <div>다음</div>
       </LoginBtn>
     </>

--- a/src/Badge/modules/redux/badge.js
+++ b/src/Badge/modules/redux/badge.js
@@ -28,9 +28,19 @@ const badgeSlice = createSlice({
     deleteActivities: (state, { payload: index }) => {
       state.activities = state.activities.filter((_, i) => i !== index);
     },
+    changeActivities: (state, { payload: { index, name, value } }) => {
+      if (state.activities[index]) {
+        state.activities[index][name] = value;
+      }
+    },
   },
 });
 
 export default badgeSlice;
-export const { changeField, initialized, addActivities, deleteActivities } =
-  badgeSlice.actions;
+export const {
+  changeField,
+  initialized,
+  addActivities,
+  deleteActivities,
+  changeActivities,
+} = badgeSlice.actions;

--- a/src/Badge/modules/redux/badge.js
+++ b/src/Badge/modules/redux/badge.js
@@ -3,6 +3,13 @@ import { createSlice } from '@reduxjs/toolkit';
 const initialState = {
   name: '',
   explain: '',
+  activities: [
+    {
+      content: '',
+      started: '',
+      ended: '',
+    },
+  ],
 };
 
 const badgeSlice = createSlice({
@@ -15,8 +22,15 @@ const badgeSlice = createSlice({
     initialized: () => {
       return initialState;
     },
+    addActivities: (state, { payload: value }) => {
+      state.activities = [...state.activities, value];
+    },
+    deleteActivities: (state, { payload: index }) => {
+      state.activities = state.activities.filter((_, i) => i !== index);
+    },
   },
 });
 
 export default badgeSlice;
-export const { changeField, initialized } = badgeSlice.actions;
+export const { changeField, initialized, addActivities, deleteActivities } =
+  badgeSlice.actions;

--- a/src/Badge/modules/redux/badge.js
+++ b/src/Badge/modules/redux/badge.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   name: '',
+  explain: '',
 };
 
 const badgeSlice = createSlice({

--- a/src/Badge/modules/redux/badge.js
+++ b/src/Badge/modules/redux/badge.js
@@ -1,0 +1,21 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  name: '',
+};
+
+const badgeSlice = createSlice({
+  name: 'badge',
+  initialState,
+  reducers: {
+    changeField: (state, { payload: { key, value } }) => {
+      state[key] = value;
+    },
+    initialized: () => {
+      return initialState;
+    },
+  },
+});
+
+export default badgeSlice;
+export const { changeField, initialized } = badgeSlice.actions;

--- a/src/Badge/pages/BadgePage.js
+++ b/src/Badge/pages/BadgePage.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { BadgeList } from '../containers/BadgeList';
 import { decodeJwtToken } from '../../Auth/modules/decodeJwtToken';
 import IssueBadgeBtn from '../components/IssueBadgeBtn';
+import { useNavigate } from 'react-router-dom';
 
 const BadgePage = () => {
   const dispatch = useDispatch();
@@ -19,7 +20,7 @@ const BadgePage = () => {
         isShowBottom: true,
       }),
     );
-  });
+  }, []);
 
   const [title, setTitle] = useState([]);
   const [align, setAlign] = useState('연도별');
@@ -51,6 +52,8 @@ const BadgePage = () => {
     ];
     setCategory(badgeTypes);
   }, [align]);
+
+  const navigate = useNavigate();
 
   const badge_info = [
     {
@@ -103,7 +106,15 @@ const BadgePage = () => {
           )}
         />
       ))}
-      {userType === 2 && <IssueBadgeBtn />}
+      {userType === 2 && (
+        <div
+          onClick={() => {
+            navigate('/badge/write');
+          }}
+        >
+          <IssueBadgeBtn />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/Badge/pages/BadgeRegisterPage.js
+++ b/src/Badge/pages/BadgeRegisterPage.js
@@ -1,5 +1,14 @@
+import { RegisterBox } from '../../Auth/styles/Auth';
+import RegisterForm from '../containers/register/RegisterForm';
+
 const BadgeRegisterPage = () => {
-  return <div>BadgeRegisterPage</div>;
+  return (
+    <>
+      <RegisterBox>
+        <RegisterForm />
+      </RegisterBox>
+    </>
+  );
 };
 
 export default BadgeRegisterPage;

--- a/src/Badge/pages/BadgeRegisterPage.js
+++ b/src/Badge/pages/BadgeRegisterPage.js
@@ -1,0 +1,5 @@
+const BadgeRegisterPage = () => {
+  return <div>BadgeRegisterPage</div>;
+};
+
+export default BadgeRegisterPage;

--- a/src/Badge/pages/BadgeRegisterPage.js
+++ b/src/Badge/pages/BadgeRegisterPage.js
@@ -1,4 +1,4 @@
-import { RegisterBox } from '../../Auth/styles/Auth';
+import { RegisterBox } from '../../styles/Survey';
 import RegisterForm from '../containers/register/RegisterForm';
 
 const BadgeRegisterPage = () => {

--- a/src/Badge/pages/BadgeRegisterPage.js
+++ b/src/Badge/pages/BadgeRegisterPage.js
@@ -1,12 +1,14 @@
-import { RegisterBox } from '../../styles/Survey';
+import { CenterGrid } from '../../styles/Survey';
 import RegisterForm from '../containers/register/RegisterForm';
 
 const BadgeRegisterPage = () => {
   return (
     <>
-      <RegisterBox>
-        <RegisterForm />
-      </RegisterBox>
+      <div>
+        <CenterGrid>
+          <RegisterForm />
+        </CenterGrid>
+      </div>
     </>
   );
 };

--- a/src/Modal/components/usedInModal/ModalButtonDiv.js
+++ b/src/Modal/components/usedInModal/ModalButtonDiv.js
@@ -7,19 +7,8 @@ import { applyFontStyles } from '../../../styles/fontStyle';
 export const ModalButtonDiv = ({ cancelText, actText, act, isRed }) => {
   const { closeModal } = useModal();
 
-  const ButtonList = {
-    alignItems: 'flex-start',
-    display: 'flex',
-    flex: '0 0 auto',
-    gap: '8px',
-    height: '48px',
-    position: 'relative',
-    width: '264px',
-    textAlign: 'center',
-  };
-
   return (
-    <div style={ButtonList}>
+    <ButtonList>
       <Cancel onClick={() => closeModal()} $isColor={Boolean(cancelText)}>
         <div className="text">{cancelText || '취소'}</div>
       </Cancel>
@@ -28,13 +17,23 @@ export const ModalButtonDiv = ({ cancelText, actText, act, isRed }) => {
           <div className="text">{actText}</div>
         </Act>
       )}
-    </div>
+    </ButtonList>
   );
 };
 
 export default ModalButtonDiv;
 
-const Cancel = styled.div`
+export const ButtonList = styled.div`
+  align-items: flex-start;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+  position: relative;
+  width: 264px;
+  text-align: center;
+`;
+
+export const Cancel = styled.div`
   background: ${(props) =>
     props.$isColor
       ? 'var(--myspec-primaryblue-1)'
@@ -56,7 +55,7 @@ const Cancel = styled.div`
     }};
   }
 `;
-const Act = styled.div`
+export const Act = styled.div`
   border-radius: 10px;
   box-sizing: border-box;
   position: relative;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './styles/common.scss';
 import './styleguide.css';
 import searchSlice from './Search/modules/redux/search.js';
+import badgeSlice from './Badge/modules/redux/badge.js';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 const queryClient = new QueryClient();
@@ -34,6 +35,7 @@ const store = configureStore({
     postwrite: postWriteSlice.reducer,
     postdetail: PostDetailSlice.reducer,
     search: searchSlice.reducer,
+    badge: badgeSlice.reducer,
   },
   devTools: true,
 });

--- a/src/styles/Survey.js
+++ b/src/styles/Survey.js
@@ -28,13 +28,14 @@ export const InputBox = styled.div`
   gap: 12px;
 
   & > input,
-  textarea {
+  textarea,
+  .inputWrapper input {
     ${applyFontStyles({
       font: 'body-01',
       color: 'var(--myspec-gray-scalegray-600)',
     })}
     border-radius: 10px;
-    background: var(--myspec-Gray-scale-Gray-200, #f2f2f2);
+    background: var(--myspec-gray-scalegray-200, #f2f2f2);
     padding: 12px 11px;
     align-items: center;
     flex-shrink: 0;

--- a/src/styles/Survey.js
+++ b/src/styles/Survey.js
@@ -27,7 +27,8 @@ export const InputBox = styled.div`
   flex-direction: column;
   gap: 12px;
 
-  & > input {
+  & > input,
+  textarea {
     ${applyFontStyles({
       font: 'body-01',
       color: 'var(--myspec-gray-scalegray-600)',
@@ -41,6 +42,7 @@ export const InputBox = styled.div`
     outline: none;
     box-sizing: border-box;
     width: 100%;
+    height: fit-content;
   }
 `;
 

--- a/src/styles/Survey.js
+++ b/src/styles/Survey.js
@@ -53,6 +53,8 @@ export const LoginBtn = styled.button`
   border: none;
   padding: 0;
   width: 100%;
+  height: fit-content;
+  align-self: end;
 
   &:disabled {
     opacity: 0.3;

--- a/src/styles/Survey.js
+++ b/src/styles/Survey.js
@@ -154,3 +154,18 @@ export const Explain = styled.div`
   })}
   padding : 8px 0px;
 `;
+
+// ---------------------BadgeWrite.js
+export const CenterGrid = styled.div`
+  display: grid;
+  grid-auto-columns: 1fr;
+  justify-content: space-between;
+  width: 375px;
+  height: calc(100vh - 88px); // 상단바
+  margin: 0px auto;
+  gap: 24px;
+  text-align: left;
+  padding-left: 16px;
+  padding-right: 16px;
+  box-sizing: border-box;
+`;

--- a/src/styles/Survey.js
+++ b/src/styles/Survey.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { applyFontStyles } from '../../styles/fontStyle';
+import { applyFontStyles } from './fontStyle';
 
 // -------------------------- LoginPage.js
 


### PR DESCRIPTION
![20240118_badge (4)](https://github.com/nada-badge/nada-frontend/assets/59547170/069c1070-48d3-418b-b782-38d6dedbb54f)
![20240118_badge (3)](https://github.com/nada-badge/nada-frontend/assets/59547170/a6d226f6-f9c5-4be1-87fa-853714ea2889)

☘완료
뱃지 관련 redux 생성 및 연결
뱃지 등록하기 컨테이너 4개 만들기

🍀앞으로 해야할 일
사진 업로드 기능 연결하기
사진 업로드 후, 뱃지 Shape 그리드 변경하기
badge.shape(webp) 만들어서, 이미지 redux로 적용하기
redux, useEffect 이용해서, 뒤로가기시 입력 데이터 유지하기

💚 요청사항
백엔드 측에, 뱃지 아이콘 서버에 (150x150)*2, . webp 형태로 저장 요청하기